### PR TITLE
[PKG-4648] 0.1.3 ❄️ 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,2 @@
-channel_sources:
-  - conda-forge/label/rust_dev,conda-forge
-
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
   - '10.12'                # [osx and x86]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,8 @@
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
-  - '10.12'                # [osx and x86]
-
+macos_min_version:
+  - 10.12 # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.12 # [osx and x86_64]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.12.sdk        # [osx and x86_64]
 rust_compiler_version:
   - '1.79.0'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
   - '10.12'                # [osx and x86]
+
+rust_compiler_version:
+  - '1.79.0'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,2 @@
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
-  - '10.12'                # [osx and x86]
-
 rust_compiler_version:
   - '1.79.0'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,5 @@
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
+  - '10.12'                # [osx and x86]
+
 rust_compiler_version:
   - '1.79.0'

--- a/recipe/mark-flaky-test.patch
+++ b/recipe/mark-flaky-test.patch
@@ -1,8 +1,16 @@
 diff --git a/tests/test_tsdownsample.py b/tests/test_tsdownsample.py
-index 993faa6..d3102f4 100644
+index 993faa6..8272495 100644
 --- a/tests/test_tsdownsample.py
 +++ b/tests/test_tsdownsample.py
-@@ -146,6 +146,7 @@ def test_parallel_downsampling_with_x(downsampler: AbstractDownsampler):
+@@ -136,6 +136,7 @@ def test_parallel_downsampling(downsampler: AbstractDownsampler):
+ 
+ 
+ @pytest.mark.parametrize("downsampler", generate_rust_downsamplers())
++@pytest.mark.flaky(reruns=5)
+ def test_parallel_downsampling_with_x(downsampler: AbstractDownsampler):
+     """Test parallel downsampling with x."""
+     arr = np.random.randn(10_001).astype(np.float32)  # 10_001 to test edge case
+@@ -146,6 +147,7 @@ def test_parallel_downsampling_with_x(downsampler: AbstractDownsampler):
  
  
  @pytest.mark.parametrize("downsampler", generate_all_downsamplers())

--- a/recipe/mark-flaky-test.patch
+++ b/recipe/mark-flaky-test.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/test_tsdownsample.py b/tests/test_tsdownsample.py
+index 993faa6..d3102f4 100644
+--- a/tests/test_tsdownsample.py
++++ b/tests/test_tsdownsample.py
+@@ -146,6 +146,7 @@ def test_parallel_downsampling_with_x(downsampler: AbstractDownsampler):
+ 
+ 
+ @pytest.mark.parametrize("downsampler", generate_all_downsamplers())
++@pytest.mark.flaky(reruns=5)
+ def test_downsampling_with_x(downsampler: AbstractDownsampler):
+     """Test downsampling with x."""
+     arr = np.random.randn(2_001).astype(np.float32)  # 2_001 to test edge case

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/tsdownsample-{{ version }}.tar.gz
   sha256: 5268d0ab5e8572138871feff389440a0c59d5e0fe02c0fa1cf975d74ba33b933
+  patches:
+    - update-argminmax.patch
 
 build:
   # maturin 0.14.x isn't available for python 3.12
@@ -18,7 +20,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('rust') }}
+    - rust 1.79.0
+    - patch
   host:
     - python
     - maturin >=0.14,<0.15

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,3 +59,5 @@ about:
 extra:
   recipe-maintainers:
     - thewchan
+  skip-lints:
+    - missing_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,8 @@ source:
     - update-argminmax.patch
 
 build:
-  # maturin 0.14.x unavailable for python 3.12
   # rust nightly unavailable on s390x
-  skip: true  # [py<37 or py>=312 or win or s390x]
+  skip: true  # [py<37 or win or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 
@@ -25,7 +24,7 @@ requirements:
     - patch
   host:
     - python
-    - maturin 0.14.17
+    - maturin 1.5.1
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/tsdownsample-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 5268d0ab5e8572138871feff389440a0c59d5e0fe02c0fa1cf975d74ba33b933
   patches:
     - update-argminmax.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,10 @@ test:
     - tsdownsample
   commands:
     - pip check
-    - pytest tests
+    - pytest tests --ignore="tests/benchmarks"
   requires:
     - pip
     - pytest
-    - pytest-cov
-    - pytest-benchmark
 
 about:
   home: https://github.com/predict-idlab/tsdownsample

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
   run:
     - python
     - numpy
-    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,9 @@ source:
     - update-argminmax.patch
 
 build:
-  # maturin 0.14.x isn't available for python 3.12
-  skip: true  # [py<37 or py>=312 or win]
+  # maturin 0.14.x unavailable for python 3.12
+  # rust nightly unavailable on s390x
+  skip: true  # [py<37 or py>=312 or win or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,18 @@ requirements:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:
+  source_files:
+    - tests
   imports:
     - tsdownsample
   commands:
     - pip check
+    - pytest tests
   requires:
     - pip
+    - pytest
+    - pytest-cov
+    - pytest-benchmark
 
 about:
   home: https://github.com/predict-idlab/tsdownsample

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - rust 1.79.0
+    - {{ compiler('rust') }}
     - patch
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-cov
+    - pytest-benchmark
 
 about:
   home: https://github.com/predict-idlab/tsdownsample

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 5268d0ab5e8572138871feff389440a0c59d5e0fe02c0fa1cf975d74ba33b933
 
 build:
-  skip: true  # [py<37 or win]
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  # maturin 0.14.x isn't available for python 3.12
+  skip: true  # [py<37 or py>=312 or win]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,11 +48,16 @@ test:
 
 about:
   home: https://github.com/predict-idlab/tsdownsample
+  dev_url: https://github.com/predict-idlab/tsdownsample
+  doc_url: https://github.com/predict-idlab/tsdownsample/blob/main/README.md
   summary: Time series downsampling in Rust
+  description: |
+    High-performance time series downsampling algorithms for visualization
   license: MIT
   license_file:
     - LICENSE
     - downsample_rs/LICENSE
+  license_family: MIT
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 5268d0ab5e8572138871feff389440a0c59d5e0fe02c0fa1cf975d74ba33b933
   patches:
     - update-argminmax.patch
+    - mark-flaky-test.patch
 
 build:
   # rust nightly unavailable on s390x
@@ -42,6 +43,7 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-rerunfailures
 
 about:
   home: https://github.com/predict-idlab/tsdownsample

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
   run:
     - python
     - numpy
-
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:
@@ -43,8 +42,6 @@ test:
   requires:
     - pip
     - pytest
-    - pytest-cov
-    - pytest-benchmark
 
 about:
   home: https://github.com/predict-idlab/tsdownsample

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - patch
   host:
     - python
-    - maturin >=0.14,<0.15
+    - maturin 0.14.17
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,6 @@ build:
 
 requirements:
   build:
-    - python                                   # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}       # [build_platform != target_platform]
-    - crossenv                                 # [build_platform != target_platform]
-    - maturin >=0.14,<0.15                     # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:

--- a/recipe/update-argminmax.patch
+++ b/recipe/update-argminmax.patch
@@ -1,0 +1,13 @@
+diff --git a/downsample_rs/Cargo.toml b/downsample_rs/Cargo.toml
+index 107469b..b7640b0 100644
+--- a/downsample_rs/Cargo.toml
++++ b/downsample_rs/Cargo.toml
+@@ -8,7 +8,7 @@ license = "MIT"
+ 
+ [dependencies]
+ # TODO: perhaps use polars?
+-argminmax = { version = "0.6.1", features = ["half"] }
++argminmax = { version = "0.6.2", features = ["half"] }
+ half = { version = "2.3.1", default-features = false , features=["num-traits"], optional = true}
+ num-traits = { version = "0.2.17", default-features = false }
+ once_cell = "1"


### PR DESCRIPTION
tsdownsample 0.1.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4648]
- [Upstream repository](https://github.com/predict-idlab/tsdownsample/tree/v0.1.3)
- [Upstream changelog/diff](https://github.com/predict-idlab/tsdownsample/releases/tag/v0.1.3)

### Explanation of changes:

- Set `rust` compiler version in conda_build_config.yaml to the nightly build present on the snowflake channel.
- Added a patch to update the version of `argminmax` from 0.6.1 to 0.6.2 due to a bug that prevented building it with `rust >=1.78`. 
  - Related upstream fix here: https://github.com/jvdd/argminmax/pull/62
- Added upstream tests. Skipping benchmark tests.
  - Set up `test_downsampling_with_x` and `test_parallel_downsampling_with_x` to rerun on failure due to both being somewhat flaky.
- Ignored `missing_wheel` lint since this recipe is using `maturin` as the build system.


[PKG-4648]: https://anaconda.atlassian.net/browse/PKG-4648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ