### PR TITLE
tsdownsample 0.1.5.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
+    - cargo-bundle-licenses
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.1.5.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -49,19 +49,17 @@ test:
 
 about:
   home: https://github.com/predict-idlab/tsdownsample
-  dev_url: https://github.com/predict-idlab/tsdownsample
-  doc_url: https://github.com/predict-idlab/tsdownsample/blob/main/README.md
-  summary: Time series downsampling in Rust
-  description: |
-    High-performance time series downsampling algorithms for visualization
   license: MIT
   license_file:
     - LICENSE
     - downsample_rs/LICENSE
   license_family: MIT
+  summary: Time series downsampling in Rust
+  description: |
+    High-performance time series downsampling algorithms for visualization
+  dev_url: https://github.com/predict-idlab/tsdownsample
+  doc_url: https://github.com/predict-idlab/tsdownsample/blob/main/README.md
 
 extra:
   recipe-maintainers:
     - thewchan
-  skip-lints:
-    - missing_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "tsdownsample" %}
-{% set version = "0.1.4.1" %}
+{% set version = "0.1.5.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cc2e2fc0031a5fb75c0f5204b498e86eae0333bcc19da481c0859f1943690f3b
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e597d6f1891f8163d9425b5f71759bfb17e3545ab72618d7ebaae0356e702829
   patches:
     # 95 | #![cfg_attr(feature = "nightly_simd", feature(avx512_target_feature))]
     # |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ source:
     - patches/0001-update-argminmax.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<38]
   script_env:
     - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1

--- a/recipe/patches/0001-update-argminmax.patch
+++ b/recipe/patches/0001-update-argminmax.patch
@@ -1,25 +1,25 @@
-From f6b2c4961570130e994eaab5d53ee091ded4d712 Mon Sep 17 00:00:00 2001
-From: Andrii Osipov <aosipov@anaconda.com>
-Date: Thu, 2 Oct 2025 05:19:55 -0700
-Subject: [PATCH] update argminmax version and features
+From 1c2d067697cdd737bf18d5af076e9db345a05006 Mon Sep 17 00:00:00 2001
+From: Andrii Vetroumov <avetroumov@anaconda.com>
+Date: Wed, 8 Jul 2026 09:32:03 +0300
+Subject: [PATCH] update argminmax
 
 ---
  downsample_rs/Cargo.toml | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/downsample_rs/Cargo.toml b/downsample_rs/Cargo.toml
-index 994e8d5..1a752f4 100644
+index 81aafd2..ed66f0d 100644
 --- a/downsample_rs/Cargo.toml
 +++ b/downsample_rs/Cargo.toml
-@@ -9,7 +9,7 @@ readme = "README.md"
+@@ -8,7 +8,7 @@ license = "MIT"
  
  [dependencies]
  # TODO: perhaps use polars?
--argminmax = { version = "0.6.1", features = ["half"] }
+-argminmax = { version = "0.6.3", features = ["half"] }
 +argminmax = { version = "0.6.2", default-features = false , features = ["float", "half"] }
- half = { version = "2.3.1", default-features = false , features=["num-traits"], optional = true}
- num-traits = { version = "0.2.17", default-features = false }
- once_cell = "1"
+ half = { version = "2.7.1", default-features = false , features=["num-traits"], optional = true}
+ num-traits = { version = "0.2.19", default-features = false }
+ once_cell = "1.21"
 -- 
-2.39.3 (Apple Git-146)
+2.54.0
 


### PR DESCRIPTION
tsdownsample 0.1.5.1 

**Destination channel:** Defaults

### Links

- [PKG-15755]
- dev_url:        https://github.com/predict-idlab/tsdownsample/tree/
- conda_forge:    https://github.com/conda-forge/tsdownsample-feedstock
- pypi:           https://pypi.org/project/tsdownsample/0.1.5.1
- pypi inspector: https://inspector.pypi.io/project/tsdownsample/0.1.5.1

### Explanation of changes:

- new version number


[PKG-15755]: https://anaconda.atlassian.net/browse/PKG-15755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ